### PR TITLE
Add core function that can change the parameter identity of variables

### DIFF
--- a/src/cchdo/hydro/core.py
+++ b/src/cchdo/hydro/core.py
@@ -20,7 +20,7 @@ from cchdo.hydro.flags import (
     ExchangeFlag,
     ExchangeSampleFlag,
 )
-from cchdo.hydro.types import FileType
+from cchdo.hydro.types import FileType, PrecisionSourceType
 from cchdo.hydro.utils import (
     add_cdom_coordinate,
     add_geometry_var,
@@ -288,6 +288,16 @@ def add_param(
     check_ancillary_variables(_ds)
 
     return _ds
+
+
+def change_params(
+    ds: xr.Dataset,
+    params: dict[WHPName | str, WHPName | str],
+    *,
+    precision_source: PrecisionSourceType | None = None,
+) -> xr.Dataset:
+    """Change the parameter identity of variables"""
+    return ds
 
 
 def add_profile_level(ds: xr.Dataset, idx, levels) -> xr.Dataset:

--- a/src/cchdo/hydro/tests/test_core_ops.py
+++ b/src/cchdo/hydro/tests/test_core_ops.py
@@ -350,3 +350,34 @@ def test_add_param_cdom():
 
     testing_ds_param = core.add_param(ds_param_325, WHPNames["CDOM300 [/METER]"])
     xr.testing.assert_identical(ds_param_cdom, testing_ds_param)
+
+
+def test_change_param():
+    params = (
+        "PH",
+        "PH_FLAG_W",
+        "PH_TMP",
+    )
+    new_params = (
+        "PH_TOT",
+        "PH_TOT_FLAG_W",
+        "PH_TMP",
+    )
+    units = ("", "", "DEG C")
+    data = (
+        "7.1234",
+        "2",
+        "20.0",
+    )
+    ds = read_exchange(
+        io.BytesIO(simple_bottle_exchange(params=params, units=units, data=data)),
+        precision_source="database",
+    )
+    ds_expected = read_exchange(
+        io.BytesIO(simple_bottle_exchange(params=new_params, units=units, data=data)),
+        precision_source="database",
+    )
+
+    result = core.change_params(ds, {"PH": "PH_TOT"})
+
+    xr.testing.assert_identical(result, ds_expected)


### PR DESCRIPTION
Adds a `change_params()` function that can change the parameter identity of variables without changing the underlying data. This is the rough equivalent of changing column labels in a CSV file without changing the data, which can occur in cases where the column is mislabeled or when a more specific parameter should be used. This would also be used to change units of the same "parameter".

Closes #54