### PR TITLE
Add support for URL ancillary variables

### DIFF
--- a/src/cchdo/hydro/__main__.py
+++ b/src/cchdo/hydro/__main__.py
@@ -333,6 +333,7 @@ def status_exchange(
                         ]
                     )
                 except KeyError:
+                    expos = ["Not Attached"]
                     crs = "<span>Not Attached</span>"
                 except IndexError:
                     log.critical(metadata["cruises"])

--- a/src/cchdo/hydro/accessors.py
+++ b/src/cchdo/hydro/accessors.py
@@ -135,7 +135,8 @@ class CCHDOAccessor:
     def __init__(self, xarray_obj: xr.Dataset):
         self._obj = xarray_obj
 
-    def jsonld(self) -> dict:
+    def jsonld(self) -> dict:  # ty:ignore[missing-type-argument]
+        # ignoring the type error here becuase the json-ld output is too complicated (also probably going away)
         # we are going to mess with it a little
         obj = self._obj.copy()
 
@@ -605,10 +606,10 @@ class CCHDOAccessor:
             *[f"{key} = {value}" for key, value in headers.items()],
         ]
 
-    def _make_data_block(self, params: dict[WHPName, xr.DataArray]) -> list[str]:
+    def _make_data_block(self, params: dict[WHPName, xr.DataArray]) -> list[list[str]]:
         # TODO N_PROF is guaranteed
         valid_levels = params[WHPNames["SAMPNO"]] != ""
-        data_block = []
+        data_block: list[list[str]] = []
         for param, da in sorted(params.items()):
             if self.file_type == FileType.CTD and (
                 param.scope != "sample" or param.nc_name == "sample"
@@ -827,7 +828,7 @@ class CCHDOAccessor:
         input_precisions = fq_get_precisions(normalized_fq)
         idxes = {key: idxer[key] for key in normalized_fq}
         # invert keys and indexes?
-        inverted: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))
+        inverted: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))  # ty:ignore[missing-type-argument]
         for key, fq_values in normalized_fq.items():
             for param, value in fq_values.items():
                 idx = idxes[key]

--- a/src/cchdo/hydro/accessors.py
+++ b/src/cchdo/hydro/accessors.py
@@ -2,9 +2,10 @@ import os
 import re
 import string
 from collections import defaultdict
+from collections.abc import Callable
 from datetime import UTC, datetime
 from io import BufferedWriter, BytesIO
-from typing import Any, Literal, NamedTuple
+from typing import Any, Literal, NamedTuple, cast
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import numpy as np
@@ -15,7 +16,6 @@ from cchdo.hydro.checks import check_flags as _check_flags
 from cchdo.hydro.core import dataarray_factory
 from cchdo.hydro.types import FileType
 from cchdo.hydro.utils import (
-    add_cdom_coordinate,
     all_same,
     extract_numeric_precisions,
     flatten_cdom_coordinate,
@@ -61,6 +61,9 @@ class FQProfileKey(NamedTuple):
     cast: int
 
 
+NormalizedFQ = list[dict[str, str | float]]
+
+
 class WHPIndxer:
     def __init__(self, obj: xr.Dataset) -> None:
         self._cache = {}
@@ -92,38 +95,107 @@ class WHPIndxer:
         self._cache[key] = ret
         return ret
 
+    def convert_fq(self, fq: NormalizedFQ) -> NormalizedFQ:
+        """Convert the FQ json to be in terms of dims actually in the dataset"""
+        new_fq = []
+        for line in fq:
+            new_line = line.copy()
+            if line.keys() >= {"EXPOCODE", "STNNBR", "CASTNO", "SAMPNO"}:
+                key = FQPointKey(
+                    str(new_line.pop("EXPOCODE")),
+                    str(new_line.pop("STNNBR")),
+                    int(new_line.pop("CASTNO")),
+                    str(new_line.pop("SAMPNO")),
+                )
+                prof_n, level_n = self[key]
+                new_line["N_PROF"] = prof_n
+                new_line["N_LEVELS"] = level_n
+            elif line.keys() >= {"EXPOCODE", "STNNBR", "CASTNO"}:
+                key = FQProfileKey(
+                    str(new_line.pop("EXPOCODE")),
+                    str(new_line.pop("STNNBR")),
+                    int(new_line.pop("CASTNO")),
+                )
+                prof_n, _level_n = self[key]
+                new_line["N_PROF"] = prof_n
+            new_fq.append(new_line)
+        return new_fq
 
-NormalizedFQ = dict[FQProfileKey | FQPointKey, dict[str, str | float]]
 
+def normalize_fq(
+    fq: list[dict[str, str | float]],
+    *,
+    check_dupes=True,
+    extra_coords: dict[str, Callable[[Any], Any]] | None = None,
+) -> NormalizedFQ:
+    fq = fq.copy()
+    if extra_coords is None:
+        extra_coords = {}
 
-def normalize_fq(fq: list[dict[str, str | float]], *, check_dupes=True) -> NormalizedFQ:
-    normalized: NormalizedFQ = defaultdict(dict)
-    key: FQProfileKey | FQPointKey
+    types = {
+        "EXPOCODE": str,
+        "STNNBR": str,
+        "CASTNO": int,
+        "SAMPNO": str,
+        "N_PROF": int,
+        "N_LEVELS": int,
+    }
+    types.update(extra_coords)
+    # one of:
+    required_keys_1 = {"EXPOCODE", "STNNBR", "CASTNO"}
+    required_keys_2 = {"N_PROF"}
+    # one of (though both are optional)
+    optional_keys_1 = {"SAMPNO"}
+    optional_keys_2 = {"N_LEVELS"}
+
+    # extend optional keys by any extra dims
+    keys = (
+        required_keys_1
+        | required_keys_2
+        | optional_keys_1
+        | optional_keys_2
+        | extra_coords.keys()
+    )
+
+    normalized: dict[tuple[Any, ...], dict[Any, Any]] = defaultdict(dict)
     for line in fq:
         line = line.copy()
-        expocode = str(line.pop("EXPOCODE"))
-        station = str(line.pop("STNNBR"))
-        cast = int(line.pop("CASTNO"))
-        try:
-            sample = str(line.pop("SAMPNO"))
-        except KeyError:
-            key = FQProfileKey(expocode, station, cast)
-        else:
-            key = FQPointKey(expocode, station, cast, sample)
+        if line.keys() >= (required_keys_1 | required_keys_2):
+            raise ValueError(
+                f"The FQ line key must either specify {required_keys_1} xor {required_keys_2} but found both"
+            )
+        if not line.keys() >= required_keys_1 and not line.keys() >= required_keys_2:
+            raise ValueError(
+                f"The FQ line key must either specify {required_keys_1} xor {required_keys_2} but found neither in {line.keys()}"
+            )
+        if line.keys() >= (optional_keys_1 | optional_keys_2):
+            raise ValueError(
+                f"The FQ line key must either specify {optional_keys_1} xor {optional_keys_2} but found both"
+            )
+
+        composite_key = tuple(sorted(keys & line.keys()))
+
+        # written in this way to preserve the order of the above composite_key
+        key = tuple(
+            types[component](line[component])
+            for component in composite_key
+            if component in line
+        )
 
         if check_dupes is True:
-            shared_keys = normalized[key].keys() & line.keys()
+            shared_keys = (normalized[key] & line.keys()) - keys
             if len(shared_keys) != 0:
                 raise ValueError(f"Duplicate input data found: {key}")
 
         normalized[key].update(line)
+        normalized[key].update(dict(zip(composite_key, key, strict=True)))
 
-    return normalized
+    return list(normalized.values())
 
 
 def fq_get_precisions(fq: NormalizedFQ) -> dict[str, int]:
     collect: dict[str, list[str]] = defaultdict(list)
-    for value in fq.values():
+    for value in fq:
         for param, data in value.items():
             if isinstance(data, str):
                 collect[param].append(data)
@@ -135,6 +207,18 @@ def fq_get_precisions(fq: NormalizedFQ) -> dict[str, int]:
 
 
 FTypeOptions = Literal["cf", "exchange", "coards", "woce"]
+
+
+@xr.register_dataarray_accessor("cchdo")
+class CCHDOAAccessor:
+    def __init__(self, xarray_obj: xr.DataArray):
+        self._obj = xarray_obj
+
+    @property
+    def whpname(self) -> WHPName | None:
+        whp_name: str | None = self._obj.attrs.get("whp_name")
+        whp_unit: str | None = self._obj.attrs.get("whp_unit")
+        return WHPNames.get((whp_name, whp_unit))
 
 
 @xr.register_dataset_accessor("cchdo")
@@ -828,38 +912,57 @@ class CCHDOAccessor:
         # * Update history attribute...
         now = datetime.now(UTC)
         new_obj = self._obj.copy(deep=True)
-        new_obj = flatten_cdom_coordinate(new_obj)
         idxer = WHPIndxer(new_obj)
 
         normalized_fq = normalize_fq(fq)
         input_precisions = fq_get_precisions(normalized_fq)
-        idxes = {key: idxer[key] for key in normalized_fq}
         # invert keys and indexes?
         inverted: dict[str, dict[str, list]] = defaultdict(lambda: defaultdict(list))  # ty:ignore[missing-type-argument]
-        for key, fq_values in normalized_fq.items():
-            for param, value in fq_values.items():
-                idx = idxes[key]
-                inverted[param]["profs"].append(idx[0])
-                inverted[param]["levels"].append(idx[1])
-                inverted[param]["values"].append(value)
+        converted_fq = idxer.convert_fq(normalized_fq)
+        for fq_json in converted_fq:
+            coords = {}
+            for coord in cast(set[str], new_obj.dims):
+                if coord in fq_json:
+                    coords[coord] = new_obj[coord].dtype.type(fq_json[coord])
+            for param, value in fq_json.items():
+                if param in coords:
+                    continue
+                for coord, coord_value in coords.items():
+                    inverted[param][coord].append(coord_value)
+
+                inverted[param]["__values"].append(value)
 
         for param, values in inverted.items():
-            whpname = WHPNames[param]
-            if whpname.error_col:
-                col_ref = new_obj[whpname.nc_name_error]
-            elif whpname.flag_col:
-                col_ref = new_obj[whpname.nc_name_flag]
+            if param in new_obj:
+                col_ref = new_obj[param]
+                whpname: WHPName | None = col_ref.cchdo.whpname
             else:
-                col_ref = new_obj[whpname.full_nc_name]
+                whpname = WHPNames[param]
+                if whpname.error_col:
+                    col_ref = new_obj[whpname.nc_name_error]
+                elif whpname.flag_col:
+                    col_ref = new_obj[whpname.nc_name_flag]
+                else:
+                    col_ref = new_obj[whpname.full_nc_name]
 
-            col_ref.values[values["profs"], values["levels"]] = values["values"]
+            __values = values.pop("__values")
+            loc_key = xr.Dataset(
+                {
+                    key: xr.DataArray(value, dims=["merge"])
+                    for key, value in values.items()
+                }
+            )
+            col_ref.loc[loc_key] = __values
 
             col_ref.attrs["date_modified"] = now.isoformat(timespec="seconds")
 
-            if (
-                param in input_precisions
-                and whpname.dtype == "decimal"
-                and not whpname.flag_col
+            if param in input_precisions and (
+                "C_format" in col_ref.attrs
+                or (
+                    whpname is not None
+                    and whpname.dtype == "decimal"
+                    and not whpname.flag_col
+                )
             ):
                 new_c_format = f"%.{input_precisions[param]}f"
                 new_c_format_source = "input_file"
@@ -872,7 +975,6 @@ class CCHDOAccessor:
                     col_ref.attrs["date_metadata_modified"] = now.isoformat(
                         timespec="seconds"
                     )
-        new_obj = add_cdom_coordinate(new_obj)
         if check_flags:
             _check_flags(new_obj)
         return new_obj

--- a/src/cchdo/hydro/accessors.py
+++ b/src/cchdo/hydro/accessors.py
@@ -748,7 +748,8 @@ class CCHDOAccessor:
                     ]
                     if error_param.error_col:
                         ancillary.attrs["whp_name"] = error_param.full_error_name
-                        params[param].attrs[ERROR_NAME] = ancillary
+                        for param in whp_params:
+                            params[param].attrs[ERROR_NAME] = ancillary
                 except KeyError:
                     pass
 

--- a/src/cchdo/hydro/accessors.py
+++ b/src/cchdo/hydro/accessors.py
@@ -63,6 +63,7 @@ class FQProfileKey(NamedTuple):
 
 class WHPIndxer:
     def __init__(self, obj: xr.Dataset) -> None:
+        self._cache = {}
         self.n_prof = pd.MultiIndex.from_arrays(
             [
                 obj.expocode.data,
@@ -77,13 +78,19 @@ class WHPIndxer:
             self.n_level.append(pd.Index(data[data != ""]))
 
     def __getitem__(self, key: FQProfileKey | FQPointKey):
+        try:
+            return self._cache[key]
+        except KeyError:
+            pass
+
         prof_idx = self.n_prof.get_loc((key.expocode, key.station, key.cast))
         if isinstance(key, FQPointKey):
             level_idx = self.n_level[prof_idx].get_loc(key.sample)
         else:
-            level_idx = slice(None)
-
-        return prof_idx, level_idx
+            level_idx = None
+        ret = prof_idx, level_idx
+        self._cache[key] = ret
+        return ret
 
 
 NormalizedFQ = dict[FQProfileKey | FQPointKey, dict[str, str | float]]

--- a/src/cchdo/hydro/checks.py
+++ b/src/cchdo/hydro/checks.py
@@ -33,7 +33,7 @@ def check_ancillary_variables(ds: xr.Dataset):
     """Check that everything in an ancillary_variables attribute appears as a variable
     Check that every variable that is known ancillary appears in at least one ancillary_variable attribute
     """
-    looks_ancillary_suffixes = ("_qc", "_error")
+    looks_ancillary_suffixes = ("_qc", "_error", "_url")
 
     ancillary_variables_attrs = defaultdict(list)
     looks_ancillary = set()

--- a/src/cchdo/hydro/core.py
+++ b/src/cchdo/hydro/core.py
@@ -1,6 +1,7 @@
 """Core operations on a CCHDO CF/netCDF file."""
 
 from collections.abc import Hashable
+from enum import StrEnum, auto
 
 import numpy as np
 import numpy.typing as npt
@@ -40,9 +41,15 @@ FLAG_SCHEME: dict[str, type[ExchangeFlag]] = {
 }
 
 
+class ColumnType(StrEnum):
+    DATA = auto()
+    FLAG = auto()
+    ERROR = auto()
+
+
 def dataarray_factory(
     param: WHPName,
-    ctype="data",
+    ctype: ColumnType = ColumnType.DATA,
     N_PROF=0,
     N_LEVELS=0,
     strlen=0,
@@ -53,25 +60,28 @@ def dataarray_factory(
     fill = FILLS_MAP[param.dtype]
     name = param.full_nc_name
 
-    if ctype == "flag":
+    if ctype == ColumnType.FLAG:
         dtype = dtype_map["integer"]
         fill = FILLS_MAP["integer"]
         name = param.nc_name_flag
 
-    if param.scope == "profile":
-        arr = np.full((N_PROF), fill_value=fill, dtype=dtype)
-    if param.scope == "sample":
-        arr = np.full((N_PROF, N_LEVELS), fill_value=fill, dtype=dtype)
+    match param.scope:
+        case "profile":
+            arr = np.full((N_PROF), fill_value=fill, dtype=dtype)
+        case "sample":
+            arr = np.full((N_PROF, N_LEVELS), fill_value=fill, dtype=dtype)
+        case "cruise":
+            arr = np.full((), fill_value=fill, dtype=dtype)
 
     attrs = param.get_nc_attrs()
     if "C_format" in attrs:
         attrs["C_format_source"] = "database"
 
-    if ctype == "error":
+    if ctype == ColumnType.ERROR:
         attrs = param.get_nc_attrs(error=True)
         name = param.nc_name_error
 
-    if ctype == "flag" and param.flag_w in FLAG_SCHEME:
+    if ctype == ColumnType.FLAG and param.flag_w in FLAG_SCHEME:
         flag_defs = FLAG_SCHEME[param.flag_w]
         flag_values = []
         flag_meanings = []
@@ -116,7 +126,7 @@ def dataarray_factory(
         if param.dtype == "integer":
             var_da = var_da.fillna(-999).astype("int32")
 
-    if ctype == "flag":
+    if ctype == ColumnType.FLAG:
         var_da.encoding["dtype"] = "int8"
         var_da.encoding["_FillValue"] = 9
 

--- a/src/cchdo/hydro/core.py
+++ b/src/cchdo/hydro/core.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Hashable
 from enum import StrEnum, auto
+from typing import cast
 
 import numpy as np
 import numpy.typing as npt
@@ -45,6 +46,7 @@ class ColumnType(StrEnum):
     DATA = auto()
     FLAG = auto()
     ERROR = auto()
+    URL = auto()
 
 
 def dataarray_factory(
@@ -53,25 +55,55 @@ def dataarray_factory(
     N_PROF=0,
     N_LEVELS=0,
     strlen=0,
+    url_shape=(),
 ) -> xr.DataArray:
     dtype = dtype_map[param.dtype]
     if param.dtype == "string":
         dtype = f"U{strlen}"
     fill = FILLS_MAP[param.dtype]
     name = param.full_nc_name
+    scope = param.scope
 
     if ctype == ColumnType.FLAG:
         dtype = dtype_map["integer"]
         fill = FILLS_MAP["integer"]
         name = param.nc_name_flag
 
-    match param.scope:
+    if ctype == ColumnType.ERROR:
+        name = param.nc_name_error
+
+    if ctype == ColumnType.URL:
+        dtype = np.dtypes.StringDType
+        fill = FILLS_MAP["string"]
+        name = f"{name}_url"  # TODO: upstream to cchdo.params
+
+        match url_shape:
+            case (int(n),) | int(n):
+                scope = cast(
+                    int, n
+                )  # TODO: remove cast when ty has support for type narrowing in match statements
+            case () if param.scope in ("sample", "profile", "cruise"):
+                scope = "cruise"
+            case ("N_PROF",) | "N_PROF" if param.scope in ("sample", "profile"):
+                scope = "profile"
+            case ("N_PROF", "N_LEVELS") if param.scope in ("sample"):
+                scope = "sample"
+            case _:
+                raise ValueError
+
+    match scope:
         case "profile":
             arr = np.full((N_PROF), fill_value=fill, dtype=dtype)
+            var_da = xr.DataArray(arr, dims=DIMS[: arr.ndim], name=name)
         case "sample":
             arr = np.full((N_PROF, N_LEVELS), fill_value=fill, dtype=dtype)
+            var_da = xr.DataArray(arr, dims=DIMS[: arr.ndim], name=name)
         case "cruise":
             arr = np.full((), fill_value=fill, dtype=dtype)
+            var_da = xr.DataArray(arr, dims=DIMS[: arr.ndim], name=name)
+        case int(n):
+            arr = np.full(n, fill_value=fill, dtype=dtype)
+            var_da = xr.DataArray(arr, dims=f"N_{name}", name=name)
 
     attrs = param.get_nc_attrs()
     if "C_format" in attrs:
@@ -79,7 +111,6 @@ def dataarray_factory(
 
     if ctype == ColumnType.ERROR:
         attrs = param.get_nc_attrs(error=True)
-        name = param.nc_name_error
 
     if ctype == ColumnType.FLAG and param.flag_w in FLAG_SCHEME:
         flag_defs = FLAG_SCHEME[param.flag_w]
@@ -101,8 +132,10 @@ def dataarray_factory(
             "flag_meanings": " ".join(flag_meanings),
             "conventions": odv_conventions_map[param.flag_w],
         }
+    if ctype == ColumnType.URL:
+        attrs = {}
 
-    var_da = xr.DataArray(arr, dims=DIMS[: arr.ndim], attrs=attrs, name=name)
+    var_da.attrs.update(attrs)
 
     if param.dtype != "decimal":
         try:
@@ -233,6 +266,7 @@ def add_param(
     with_flag: bool = False,
     with_error: bool = False,
     with_ancillary=None,
+    with_url=None,
 ) -> xr.Dataset:
     """Add a new parameter, and optionally some ancillary associated variables to a dataset.
 
@@ -262,17 +296,16 @@ def add_param(
         )
         vars_to_add.append(var)
 
+    ancillary: set[str] = set(var.attrs.get("ancillary_variables", "").split())
+
     if with_flag and _param.nc_name_flag not in _ds:
         flag_var = dataarray_factory(
             _param,
             N_PROF=ds.sizes["N_PROF"],
             N_LEVELS=ds.sizes["N_LEVELS"],
-            ctype="flag",
+            ctype=ColumnType.FLAG,
         )
-        ancillary = var.attrs.get("ancillary_variables", "").split()
-        if flag_var.name not in ancillary:
-            ancillary.append(flag_var.name)
-        var.attrs["ancillary_variables"] = " ".join(sorted(ancillary))
+        ancillary.add(str(flag_var.name))
         vars_to_add.append(flag_var)
 
     if with_error and _param.full_error_name is None:
@@ -283,16 +316,29 @@ def add_param(
             _param,
             N_PROF=ds.sizes["N_PROF"],
             N_LEVELS=ds.sizes["N_LEVELS"],
-            ctype="error",
+            ctype=ColumnType.ERROR,
         )
-        ancillary = var.attrs.get("ancillary_variables", "").split()
-        if error_var.name not in ancillary:
-            ancillary.append(error_var.name)
-        var.attrs["ancillary_variables"] = " ".join(sorted(ancillary))
+        ancillary.add(str(error_var.name))
         vars_to_add.append(error_var)
 
-    for var in vars_to_add:
-        _ds[var.name] = var
+    if (
+        with_url is not None and f"{_param.full_nc_name}_url" not in _ds
+    ):  # TODO: upstream to cchdo.params
+        url_var = dataarray_factory(
+            _param,
+            N_PROF=ds.sizes["N_PROF"],
+            N_LEVELS=ds.sizes["N_LEVELS"],
+            ctype=ColumnType.URL,
+            url_shape=with_url,
+        )
+        ancillary.add(str(url_var.name))
+        vars_to_add.append(url_var)
+
+    if ancillary:
+        var.attrs["ancillary_variables"] = " ".join(sorted(ancillary))
+
+    for add_var in vars_to_add:
+        _ds[add_var.name] = add_var
 
     _ds = add_cdom_coordinate(_ds)
     check_ancillary_variables(_ds)

--- a/src/cchdo/hydro/core.py
+++ b/src/cchdo/hydro/core.py
@@ -104,6 +104,8 @@ def dataarray_factory(
         case int(n):
             arr = np.full(n, fill_value=fill, dtype=dtype)
             var_da = xr.DataArray(arr, dims=f"N_{name}", name=name)
+        case _:
+            raise ValueError(f"found unknown scope, got {scope}")
 
     attrs = param.get_nc_attrs()
     if "C_format" in attrs:

--- a/src/cchdo/hydro/core.py
+++ b/src/cchdo/hydro/core.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Hashable
 from enum import StrEnum, auto
-from typing import cast
+from typing import Literal, cast
 
 import numpy as np
 import numpy.typing as npt
@@ -49,13 +49,21 @@ class ColumnType(StrEnum):
     URL = auto()
 
 
+URL_SHAPE = (
+    int
+    | tuple[()]
+    | tuple[Literal["N_PROF"]]
+    | tuple[Literal["N_PROF"], Literal["N_LEVELS"]]
+)
+
+
 def dataarray_factory(
     param: WHPName,
     ctype: ColumnType = ColumnType.DATA,
     N_PROF=0,
     N_LEVELS=0,
     strlen=0,
-    url_shape=(),
+    url_shape: URL_SHAPE = (),
 ) -> xr.DataArray:
     dtype = dtype_map[param.dtype]
     if param.dtype == "string":
@@ -177,6 +185,7 @@ def remove_param(
     delete_param: bool = False,
     delete_flag: bool = False,
     delete_error: bool = False,
+    delete_url: bool = False,
     delete_ancillary=False,
     require_empty: bool = True,
 ) -> xr.Dataset:

--- a/src/cchdo/hydro/exchange/__init__.py
+++ b/src/cchdo/hydro/exchange/__init__.py
@@ -31,7 +31,7 @@ from cchdo.hydro.consts import (
     STNNBR,
     TIME,
 )
-from cchdo.hydro.core import dataarray_factory
+from cchdo.hydro.core import ColumnType, dataarray_factory
 from cchdo.hydro.dt import combine_dt
 from cchdo.hydro.exchange.exceptions import (
     ExchangeBOMError,
@@ -1061,14 +1061,14 @@ def _from_exchange_data(
         if param in flags:
             qc_name = param.nc_name_flag
             dataarrays[qc_name] = dataarray_factory(
-                param, ctype="flag", N_PROF=N_PROF, N_LEVELS=N_LEVELS
+                param, ctype=ColumnType.FLAG, N_PROF=N_PROF, N_LEVELS=N_LEVELS
             )
             dataarrays[param.full_nc_name].attrs["ancillary_variables"].append(qc_name)
 
         if param in errors:
             error_name = param.nc_name_error
             dataarrays[error_name] = dataarray_factory(
-                param, ctype="error", N_PROF=N_PROF, N_LEVELS=N_LEVELS
+                param, ctype=ColumnType.ERROR, N_PROF=N_PROF, N_LEVELS=N_LEVELS
             )
             dataarrays[param.full_nc_name].attrs["ancillary_variables"].append(
                 error_name

--- a/src/cchdo/hydro/legacy/woce/__init__.py
+++ b/src/cchdo/hydro/legacy/woce/__init__.py
@@ -134,7 +134,7 @@ def get_filename(expocode, station, cast, file_ext):
 # END machinery
 
 
-def convert_fortran_format_to_c(ffmt: str):
+def convert_fortran_format_to_c(ffmt: str | None):
     """Simplistic conversion from Fortran format string to C format string.
 
     This only operates on F formats.
@@ -171,18 +171,16 @@ def get_exwoce_params():
 
             if row[-1] == "x":
                 continue
-            if not row[1]:
-                row[1] = None
+            unit_mnemonic = row[1] if row[1] != "" else None
             if row[2]:
                 prange = list(map(float, row[2].split(",")))
             else:
                 prange = None
-            if not row[3]:
-                row[3] = None
+            ffmt = row[3] if row[3] != "" else None
             params[row[0]] = {
-                "unit_mnemonic": row[1],
+                "unit_mnemonic": unit_mnemonic,
                 "range": prange,
-                "format": convert_fortran_format_to_c(row[3]),
+                "format": convert_fortran_format_to_c(ffmt),
                 "order": order,
             }
         return params

--- a/src/cchdo/hydro/rename.py
+++ b/src/cchdo/hydro/rename.py
@@ -11,7 +11,7 @@ def is_not_none(obj):
 
 def rename_with_bookkeeping(
     xarray_obj: Dataset,
-    name_dict: Mapping | None = None,
+    name_dict: Mapping[str, str] | None = None,
     attrs: list[str] | None = None,
 ) -> Dataset:
     """Find and update all instances of a given variable to a new name.

--- a/src/cchdo/hydro/tests/test_merge.py
+++ b/src/cchdo/hydro/tests/test_merge.py
@@ -127,7 +127,8 @@ def test_fq_merge_cdom(nc_placeholders):
             "STNNBR": "1",
             "CASTNO": 1,
             "SAMPNO": "36",
-            "CDOM300 [/METER]": "100.2",
+            "CDOM_WAVELENGTHS": 300,
+            "cdom": "100.2",
         }
     ]
     merged = nc_placeholders.cchdo.merge_fq(fq)
@@ -141,7 +142,8 @@ def test_fq_merge_cdom(nc_placeholders):
             "STNNBR": "1",
             "CASTNO": 1,
             "SAMPNO": "36",
-            "CDOM325 [/METER]": "100.2",
+            "CDOM_WAVELENGTHS": 325,
+            "cdom": "100.2",
         }
     ]
     merged = nc_placeholders.cchdo.merge_fq(fq)

--- a/src/cchdo/hydro/tutorial.py
+++ b/src/cchdo/hydro/tutorial.py
@@ -1,6 +1,7 @@
 import io
 import os
-from collections.abc import Mapping
+import typing
+from collections.abc import Generator, Mapping
 from zipfile import ZipFile
 
 import requests
@@ -28,7 +29,7 @@ def load_cchdo_bottle_data():
                     f.write(chunk)
 
 
-class CCHDOBottleData(Mapping):
+class CCHDOBottleData(Mapping[str, io.BytesIO]):
     def __init__(self):
         self.path = os.path.join(_hydro_platformdirs.user_cache_dir, bottle_fname)
         try:
@@ -39,13 +40,16 @@ class CCHDOBottleData(Mapping):
             with ZipFile(self.path) as f:
                 self.files = f.namelist()
 
-    def __len__(self):
+    @typing.override
+    def __len__(self) -> int:
         return len(self.files)
 
-    def __iter__(self):
+    @typing.override
+    def __iter__(self) -> Generator[str]:
         yield from self.files
 
-    def __getitem__(self, key):
+    @typing.override
+    def __getitem__(self, key: str) -> io.BytesIO:
         if key not in self.files:
             raise KeyError()
         with ZipFile(self.path) as f:

--- a/src/cchdo/hydro/utils.py
+++ b/src/cchdo/hydro/utils.py
@@ -89,6 +89,9 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
 
     # useful for later coping of attrs
     first = cdom_data[0]
+    whp_name = first.attrs["whp_name"]
+    whp_unit = first.attrs["whp_unit"]
+    whpname = WHPNames[(whp_name, whp_unit)]
 
     # "None in" doesn't seem to work due to xarray comparison?
     none_in_qc = [da is None for da in cdom_qc]
@@ -98,9 +101,6 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
     radiation_wavelengths = []
     c_formats = []
     for dataarray in cdom_data:
-        whp_name = dataarray.attrs["whp_name"]
-        whp_unit = dataarray.attrs["whp_unit"]
-        whpname = WHPNames[(whp_name, whp_unit)]
         radiation_wavelengths.append(whpname.radiation_wavelength)
         if "C_format" in dataarray.attrs:
             c_formats.append(dataarray.attrs["C_format"])
@@ -120,10 +120,10 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
         "CDOM_WAVELENGTHS": cdom_wavelengths,
     }
 
-    has_qc = False
     # qc flags first if any
+    first_qc: xr.DataArray | None = None
+    new_cdom_qc: xr.DataArray | None = None
     if _is_all_dataarray(cdom_qc):
-        has_qc = True
         cdom_qc_arrays = np.stack(cdom_qc, axis=-1)
         first_qc = cdom_qc[0]
 
@@ -146,7 +146,7 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
 
     new_qc_name = f"{whpname.nc_group}_qc"
 
-    if has_qc:
+    if new_cdom_qc is not None:
         new_cdom_attrs["ancillary_variables"] = new_qc_name
 
     new_cdom = xr.DataArray(
@@ -157,7 +157,7 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
     dataset[first.name] = new_cdom
     dataset = dataset.rename({first.name: whpname.nc_group})
 
-    if has_qc:
+    if new_cdom_qc is not None and first_qc is not None:
         dataset[first_qc.name] = new_cdom_qc
         dataset = dataset.rename({first_qc.name: new_qc_name})
 

--- a/src/cchdo/hydro/utils.py
+++ b/src/cchdo/hydro/utils.py
@@ -89,9 +89,7 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
 
     # useful for later coping of attrs
     first = cdom_data[0]
-    whp_name = first.attrs["whp_name"]
-    whp_unit = first.attrs["whp_unit"]
-    whpname = WHPNames[(whp_name, whp_unit)]
+    whpname = WHPNames[(first.attrs["whp_name"], first.attrs["whp_unit"])]
 
     # "None in" doesn't seem to work due to xarray comparison?
     none_in_qc = [da is None for da in cdom_qc]
@@ -101,6 +99,7 @@ def add_cdom_coordinate(dataset: xr.Dataset) -> xr.Dataset:
     radiation_wavelengths = []
     c_formats = []
     for dataarray in cdom_data:
+        whpname = WHPNames[(dataarray.attrs["whp_name"], dataarray.attrs["whp_unit"])]
         radiation_wavelengths.append(whpname.radiation_wavelength)
         if "C_format" in dataarray.attrs:
             c_formats.append(dataarray.attrs["C_format"])


### PR DESCRIPTION
Adds support for the creation of string type ancillary variables of various shapes that can be attached to primary variables. The intent for now is to link to external data sets and not to, for example, methods papers or documentation.

TODO:

- [ ] Remove URI param
- [x] editing machinery (won't work with normal fq) maybe add station/cast/[sample] indexing support?
- [ ] sort out attrs, CF might use a standard name or might use something like "cf_role", we cannot wait on this so will probably just do a "cchdo_role" attr
- [ ] exchange export support
- [ ] tests